### PR TITLE
Chatspaceの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
    if ( message.image ) {
      var html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
          <div class="upper-message">
            <div class="upper-message__user-name">
              ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
      return html;
    } else {
      var html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
          <div class="upper-message">
            <div class="upper-message__user-name">
              ${message.user_name}
@@ -39,24 +39,50 @@ $(function(){
      return html;
    };
  }
-$('#new_message').on('submit', function(e){
- e.preventDefault();
- var formData = new FormData(this);
- var url = $(this).attr('action')
- $.ajax({
-   url: url,
-   type: "POST",
-   data: formData,
-   dataType: 'json',
-   processData: false,
-   contentType: false
- })
-  .done(function(data){
-    var html = buildHTML(data);
-    $('.main_chat').append(html);
-    $('form')[0].reset();
-    $('.main_chat').animate({ scrollTop: $('.main_chat')[0].scrollHeight});
-    $('.send_btn').prop('disabled', false);
+  $('#new_message').on('submit', function(e){
+  e.preventDefault();
+  var formData = new FormData(this);
+  var url = $(this).attr('action')
+  $.ajax({
+    url: url,
+    type: "POST",
+    data: formData,
+    dataType: 'json',
+    processData: false,
+    contentType: false
   })
-})
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.main_chat').append(html);
+      $('form')[0].reset();
+      $('.main_chat').animate({ scrollTop: $('.main_chat')[0].scrollHeight});
+      $('.send_btn').prop('disabled', false);
+    })
+  })
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ? ", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.text @message.text
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 
 end


### PR DESCRIPTION
# WHAT

https://i.gyazo.com/c5bb4b45bb48cdd6ca47d5ffdb614bfe.gif

■message.js
setInterval(function() {
} , 7000 );
→で7秒おきにajax通信を行う関数が発動
するように設定

data-message-id="${message.id}"
→idで条件分岐ができるようにするために、クラスにidを付与。data-message-idとしているのは、非同期通信で一度イベント発火させた際に追加するHTMLのビューであるため。

$('#message').append(insertHTML);
scroll()
→appendした後に、最新のチャットを見れるようにするために自動スクロールを追加

■messages_controller.rb
respond_to do |format|
format.html
format.json
end
→json形式でデータ処理ができるように設定

■index.json.jbuilder
→messages_controller.rbのindexアクションで取得してきた@messagesは配列で複数データを保有している可能性があるので、each文を使用して要素一つ一つのデータをjsonで受け取れるように処理
→message.jsで、自動更新する際に新しく追加されたmessageを
if(message.id > id){
と条件分岐で取得できるようにするために、message.idも今回は追加で取得できるように設定

# WHY
ログインユーザーが、自分以外のユーザーがチャットをした際に、リロードすることなく、最新のチャットを見て、すぐにレスポンスを返すことができるようにするため